### PR TITLE
fix: PR preview vite base path

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,9 +21,7 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run build
-        env:
-          VITE_BASE: /metaflow-hello-web-test/pr/${{ github.event.number }}/
+      - run: npx vite build --base=/metaflow-hello-web-test/pr/${{ github.event.number }}/
 
       - uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.6.0",
@@ -1112,6 +1113,14 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3946,6 +3955,36 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/redent": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ function healthEndpoint(): Plugin {
 
 export default defineConfig({
   plugins: [react(), healthEndpoint()],
-  base: (process.env as Record<string, string>).VITE_BASE ?? '/metaflow-hello-web-test/',
+  base: '/metaflow-hello-web-test/',
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
Pass `--base` via Vite CLI flag instead of `process.env` which requires `@types/node`.